### PR TITLE
Exposed interface for "build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ The following methods are available on the object returned by `picoModal`:
 * __closeElem__: Returns the close button DOM Node
 * __overlayElem__: Returns the overlay DOM Node
 * __show__: Displays the modal
+* __build__: Build the DOM for the modal, but don't show it yet (keep display: none)
 * __close__: Hides the modal
 * __forceClose__: Hides the modal without calling the beforeClose events
 * __destroy__: Detaches all DOM Nodes and unhooks this modal

--- a/src/picoModal.js
+++ b/src/picoModal.js
@@ -174,7 +174,7 @@
             .clazz("pico-overlay")
             .clazz( getOption("overlayClass", "") )
             .stylize({
-                display: "block",
+                display: "none",
                 position: "fixed",
                 top: "0px",
                 left: "0px",
@@ -204,7 +204,7 @@
             .clazz("pico-content")
             .clazz( getOption("modalClass", "") )
             .stylize({
-                display: 'block',
+                display: 'none',
                 position: 'fixed',
                 zIndex: 10001,
                 left: "50%",
@@ -360,6 +360,9 @@
                 }
                 return this;
             },
+
+            /** Builds the dom of the modal */
+            build: returnIface(build),
 
             /** Hides this modal */
             close: returnIface(close),


### PR DESCRIPTION
Useful when building the dom for the modal is expensive or it needs to be prebuilt before displaying for any other reason (eg. dynamic compilation). Updated README.md to reflect this.