### PR TITLE
Fix - avoid having undefined as a class name for pico-close

### DIFF
--- a/src/picoModal.js
+++ b/src/picoModal.js
@@ -255,7 +255,7 @@
             return elem.child()
                 .html( getOption('closeHtml', "&#xD7;") )
                 .clazz("pico-close")
-                .clazz( getOption("closeClass") )
+                .clazz( getOption("closeClass", "") )
                 .stylize( getOption('closeStyles', {
                     borderRadius: "2px",
                     cursor: "pointer",


### PR DESCRIPTION
Hi,

I just fixed a minor issue to avoid having `undefined` as a class name for the `pico-close` DOM object.

Best regards

Erwan