### PR TITLE
Able to select an alternative parent for the modal dialog box

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The following settings are available when creating a modal:
 * __modalClass__: A class to attach to the main modal element
 * __overlayClass__: A class to attach to the overlay element
 * __closeClass__: A class to attach to the close button
+* __parentNodeId__: The modal dialog box is attached to the `body` element by default, but you can select an alternative parent element by specifying a parent's ID
 
 If a method is passed as an argument for any of the settings, it will be
 called. The first argument passed in is the default value for that setting. This

--- a/src/picoModal.js
+++ b/src/picoModal.js
@@ -255,7 +255,7 @@
             return elem.child()
                 .html( getOption('closeHtml', "&#xD7;") )
                 .clazz("pico-close")
-                .clazz( getOption("closeClass") )
+                .clazz( getOption("closeClass", "") )
                 .stylize( getOption('closeStyles', {
                     borderRadius: "2px",
                     cursor: "pointer",

--- a/src/picoModal.js
+++ b/src/picoModal.js
@@ -146,7 +146,7 @@
 
         /** Removes this element from the DOM */
         destroy: function() {
-            document.body.removeChild(this.elem);
+            (this.elem.parentNode || document.body).removeChild(this.elem);
         },
 
         /** Hides this element */
@@ -182,8 +182,9 @@
 
 
     /** Generates the grey-out effect */
-    function buildOverlay( getOption, close ) {
-        return Elem.div()
+    function buildOverlay( getOption, close ) {        
+        return Elem.div(
+            document.getElementById(getOption("parentNodeId", "")))
             .clazz("pico-overlay")
             .clazz( getOption("overlayClass", "") )
             .stylize({
@@ -213,7 +214,8 @@
             width = "" + width + "px";
         }
 
-        var elem = Elem.div()
+        var elem = Elem.div(
+            document.getElementById(getOption("parentNodeId", "")))
             .clazz("pico-content")
             .clazz( getOption("modalClass", "") )
             .stylize({


### PR DESCRIPTION
Hi, 

First of all, thank you for your project, and for the quality of your source code.

I am proposing an enhancement to your project, because I faced an issue for displaying the modal dialog box on top of a video in full screen mode.

Rendering a video in full screen mode has always impacts, as you can see in that article for example : https://css-tricks.com/custom-controls-in-html5-video-full-screen/

Using your modal dialog box as it is today, won't work, because the traditional way to display elements on top of the video player is to set the z-index with the 2147483647 value (cf. the previous article).

In your case, you must have two layers, one for the overlay, and another one for the modal dialog box, so the usual trick with the 2147483647 value does not work, because if you set the overlay layer to a lower value (let's say 2147483646) it will be displayed under the player, and you can not specify a value greater than 2147483647, because it is the maximum value.

As I wanted to keep the overlay layer, I managed to make it, by attaching the overlay, and the modal dialog box elements to the video container, and not to the body element.

So, that's why I am proposing an enhancement in your source code, to be able to select an alternative parent (and not always attaching the modal dialog box to the body).

I tried to respect the spirit of your source code, and to stay generic, and not only focused on my problem.

I hope it helps

Best regards

Erwan

PS : In my source code, there is also the fix from my other pull request available on https://github.com/Nycto/PicoModal/pull/17

 